### PR TITLE
Some more shortenings

### DIFF
--- a/config.ru
+++ b/config.ru
@@ -1,8 +1,8 @@
 %w(action_controller/railtie coderay).each &method(:require)
 
-run TheSmallestRailsApp ||= Class.new(Rails::Application) {
+run Class.new(Rails::Application) {
   config.secret_token = routes.append { root to: 'hello#world' }.inspect
-  tap &:initialize!
+  initialize!
 }
 
 class HelloController < ActionController::Base


### PR DESCRIPTION
Since you're using `Class.new`, you don't actually need to assign that to a constant. Anonymous classes work fine.

Secondly, we no longer need to use `tap`. Class definitions return the last thing evaluated in the body, which is why `tap` was required before. Since `Class.new` always returns the class it creates, the `tap` is unnecessary
