### PR TITLE
remove rvm version from travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,3 @@
 language: ruby
 sudo: false
 script: bundle exec ruby test.rb
-rvm:
-  - 2.2.2


### PR DESCRIPTION
travis can deal with the `.ruby-version` file